### PR TITLE
Update Apriltag Rotation to use aimAtTarget

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": false,
     "currentLanguage": "java",
     "projectYear": "2025",
-    "teamNumber": 3481
+    "teamNumber": 3673
 }

--- a/src/main/deploy/swerve/neo/modules/backleft.json
+++ b/src/main/deploy/swerve/neo/modules/backleft.json
@@ -15,7 +15,7 @@
     "canbus": "rio"
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderOffset": 232.2072,

--- a/src/main/deploy/swerve/neo/modules/backright.json
+++ b/src/main/deploy/swerve/neo/modules/backright.json
@@ -15,7 +15,7 @@
     "canbus": "rio"
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderOffset": 12.8322,

--- a/src/main/deploy/swerve/neo/modules/frontleft.json
+++ b/src/main/deploy/swerve/neo/modules/frontleft.json
@@ -15,7 +15,7 @@
     "canbus": "rio"
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderOffset": 243.01764,

--- a/src/main/deploy/swerve/neo/modules/frontright.json
+++ b/src/main/deploy/swerve/neo/modules/frontright.json
@@ -15,7 +15,7 @@
     "canbus": "rio"
   },
   "inverted": {
-    "drive": false,
+    "drive": true,
     "angle": true
   },
   "absoluteEncoderOffset": 63.4572,

--- a/src/main/deploy/swerve/neo/swervedrive.json
+++ b/src/main/deploy/swerve/neo/swervedrive.json
@@ -5,7 +5,7 @@
     "id": 2,
     "canbus": "rio"
   },
-  "invertedIMU": false,
+  "invertedIMU": true,
   "modules": [
     "frontleft.json",
     "frontright.json",

--- a/src/main/deploy/swerve/neo/swervedrive.json
+++ b/src/main/deploy/swerve/neo/swervedrive.json
@@ -5,7 +5,7 @@
     "id": 2,
     "canbus": "rio"
   },
-  "invertedIMU": true,
+  "invertedIMU": false,
   "modules": [
     "frontleft.json",
     "frontright.json",

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,6 +4,8 @@
 
 package frc.robot;
 
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.util.Units;
 import swervelib.math.Matter;
@@ -55,6 +57,38 @@ public final class Constants
   public static final double SWERVE_SPEED_SLOW = 0.5;
 
   public static final double VISION_TURN_kP = 0.01;
+
+  public static final AprilTagFieldLayout FIELD_LAYOUT = AprilTagFieldLayout.loadField(AprilTagFields.k2025Reefscape);
+
+  //Measured as the distance from the floor to the center of the Apriltag, in meters.
+  public static final double[] APRILTAG_HEIGHTS = 
+  {
+    FIELD_LAYOUT.getTagPose(1).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(2).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(3).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(4).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(5).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(6).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(7).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(8).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(9).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(10).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(11).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(12).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(13).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(14).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(15).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(16).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(17).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(18).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(19).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(20).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(21).get().getTranslation().getZ(),
+    FIELD_LAYOUT.getTagPose(22).get().getTranslation().getZ()
+    //After This is Unofficial Heights for Testing Purposes.
+  };
+
+
 
 
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -84,8 +84,9 @@ public final class Constants
     FIELD_LAYOUT.getTagPose(19).get().getTranslation().getZ(),
     FIELD_LAYOUT.getTagPose(20).get().getTranslation().getZ(),
     FIELD_LAYOUT.getTagPose(21).get().getTranslation().getZ(),
-    FIELD_LAYOUT.getTagPose(22).get().getTranslation().getZ()
+    FIELD_LAYOUT.getTagPose(22).get().getTranslation().getZ(),
     //After This is Unofficial Heights for Testing Purposes.
+    Units.inchesToMeters(18)
   };
 
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -86,7 +86,8 @@ public final class Constants
     FIELD_LAYOUT.getTagPose(21).get().getTranslation().getZ(),
     FIELD_LAYOUT.getTagPose(22).get().getTranslation().getZ(),
     //After This is Unofficial Heights for Testing Purposes.
-    Units.inchesToMeters(18)
+    Units.inchesToMeters(18),
+    Units.inchesToMeters(37.5)
   };
 
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -57,8 +57,9 @@ public class Robot extends TimedRobot
 
   private Timer disabledTimer;
 
-  //private PhotonCamera camera = new PhotonCamera("centerCam");
-  private PhotonCamera visionCamera;
+  //private SwerveSubsystem drivebase;
+
+  //private PhotonCamera visionCamera;
 
   private Cameras cameraEnum = Cameras.CENTER_CAM;
 
@@ -109,7 +110,7 @@ public class Robot extends TimedRobot
     //colorMatcher.addColorMatch(whiteTarget);
     //colorMatcher.addColorMatch(background);
 
-    visionCamera = new PhotonCamera(cameraName);
+    //visionCamera = new PhotonCamera(cameraName);
 
     
 
@@ -243,6 +244,8 @@ public class Robot extends TimedRobot
   @Override
   public void teleopPeriodic()
   {
+    /*
+    
 
     if (visionCamera != null) {
       double forward = -m_robotContainer.logitechController.getLeftY() * Constants.MAX_SPEED;
@@ -276,8 +279,9 @@ public class Robot extends TimedRobot
       // Driver wants auto-alignment to tag 14
               // And, tag 14 is in sight, so we can turn toward it.
               // Override the driver's turn command with an automatic one that turns toward the tag.
-              turn = -1.0 * targetYaw * Constants.VISION_TURN_kP * Constants.MAX_ANGULAR_SPEED;
-              System.out.println(turn);
+              //turn = -1.0 * targetYaw * Constants.VISION_TURN_kP * Constants.MAX_ANGULAR_SPEED;
+              //System.out.println(turn);
+              drivebase.aimAtTarget(cameraEnum);
 
     }
 
@@ -291,6 +295,7 @@ public class Robot extends TimedRobot
 
 
     }
+    */
     
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -57,18 +57,6 @@ public class Robot extends TimedRobot
 
   private Timer disabledTimer;
 
-  //private SwerveSubsystem drivebase;
-
-  //private PhotonCamera visionCamera;
-
-  private Cameras cameraEnum = Cameras.CENTER_CAM;
-
-  private String cameraName = cameraEnum.name();
-
-  
-
-
-
   UsbCamera cam0;
 
   //https://rgbcolorpicker.com/0-1
@@ -244,58 +232,6 @@ public class Robot extends TimedRobot
   @Override
   public void teleopPeriodic()
   {
-    /*
-    
-
-    if (visionCamera != null) {
-      double forward = -m_robotContainer.logitechController.getLeftY() * Constants.MAX_SPEED;
-      double strafe = -m_robotContainer.logitechController.getLeftX() * Constants.MAX_SPEED;
-      double turn = -m_robotContainer.logitechController.getRightX() * Constants.MAX_ANGULAR_SPEED;
-      
-
-      boolean targetVisible = false;
-      double targetYaw = 0.0;
-      //var results = camera.getAllUnreadResults();
-      //var results = Cameras.CENTER_CAM.camera.getAllUnreadResults();
-      var results = cameraEnum.camera.getAllUnreadResults();
-      if (!results.isEmpty()) {
-        // Camera processed a new frame since last
-        // Get the last one in the list.
-        var result = results.get(results.size() - 1);
-        if (result.hasTargets()) {
-            // At least one AprilTag was seen by the camera
-            for (var target : result.getTargets()) {
-                if (target.getFiducialId() == 14) {
-                    // Found Tag 14, record its information
-                    targetYaw = target.getYaw();
-                    targetVisible = true;
-                }
-            }
-        }
-          
-    }
-
-    if (m_robotContainer.logitechController.a().getAsBoolean() && targetVisible) {
-      // Driver wants auto-alignment to tag 14
-              // And, tag 14 is in sight, so we can turn toward it.
-              // Override the driver's turn command with an automatic one that turns toward the tag.
-              //turn = -1.0 * targetYaw * Constants.VISION_TURN_kP * Constants.MAX_ANGULAR_SPEED;
-              //System.out.println(turn);
-              drivebase.aimAtTarget(cameraEnum);
-
-    }
-
-
-            // Command drivetrain motors based on target speeds
-            m_robotContainer.drivebase.drive(new Translation2d(forward, strafe), turn, true);
-
-            // Put debug information to the dashboard
-            SmartDashboard.putBoolean("Is Target Visible?: ", targetVisible);
-
-
-
-    }
-    */
     
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -10,6 +10,9 @@ import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.cscore.UsbCamera;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.trajectory.constraint.MaxVelocityConstraint;
+import edu.wpi.first.util.datalog.DataLog;
+import edu.wpi.first.util.datalog.DoubleLogEntry;
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
@@ -61,6 +64,11 @@ public class Robot extends TimedRobot
 
   UsbCamera cam0;
 
+  private DataLog dataLog;
+  public DoubleLogEntry aimAtTargetDegrees;
+  public DoubleLogEntry aimAtTargetRadians;
+  public DoubleLogEntry aimAtTargetDegreesNonAdj;
+
   //https://rgbcolorpicker.com/0-1
   //private final Color GreenTarget = new Color(0.197, 0.561, 0.240);
   //private final Color RedTarget = new Color(0.561, 0.232, 0.114);
@@ -103,6 +111,12 @@ public class Robot extends TimedRobot
     //colorMatcher.addColorMatch(background);
 
     //visionCamera = new PhotonCamera(cameraName);
+
+    DataLogManager.start();
+    dataLog = DataLogManager.getLog();
+    aimAtTargetDegrees = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetDegrees");
+    aimAtTargetRadians = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetRadians");
+    aimAtTargetDegreesNonAdj = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetNonADJ");
 
     
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -57,6 +57,8 @@ public class Robot extends TimedRobot
 
   private Timer disabledTimer;
 
+  private Cameras cameraEnum = Cameras.CENTER_CAM;
+
   UsbCamera cam0;
 
   //https://rgbcolorpicker.com/0-1
@@ -84,6 +86,8 @@ public class Robot extends TimedRobot
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+
+    m_robotContainer.drivebase.setupPhotonVision();
 
     // Create a timer to disable motor brake a few seconds after disable.  This will let the robot stop
     // immediately when disabled, but then also let it be pushed more 
@@ -232,7 +236,7 @@ public class Robot extends TimedRobot
   @Override
   public void teleopPeriodic()
   {
-    
+    m_robotContainer.vision.getEstimatedGlobalPose(cameraEnum); //Forces camera update.
   }
 
   @Override

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -112,11 +112,11 @@ public class Robot extends TimedRobot
 
     //visionCamera = new PhotonCamera(cameraName);
 
-    DataLogManager.start();
-    dataLog = DataLogManager.getLog();
-    aimAtTargetDegrees = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetDegrees");
-    aimAtTargetRadians = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetRadians");
-    aimAtTargetDegreesNonAdj = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetNonADJ");
+    //DataLogManager.start();
+    //dataLog = DataLogManager.getLog();
+    //aimAtTargetDegrees = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetDegrees");
+    //aimAtTargetRadians = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetRadians");
+    //aimAtTargetDegreesNonAdj = new DoubleLogEntry(dataLog, "/Vision/aimAtTargetNonADJ");
 
     
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -85,9 +85,6 @@ public class RobotContainer
   private Cameras cameraEnum = Cameras.CENTER_CAM;
 
 
-  
-
-
   /**
    * Converts driver input into a field-relative ChassisSpeeds that is controlled by angular velocity.
    */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -40,6 +40,7 @@ import frc.robot.subsystems.swervedrive.Elevator;
 import frc.robot.subsystems.swervedrive.Feeder;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 import frc.robot.subsystems.swervedrive.Vision;
+import frc.robot.subsystems.swervedrive.Vision.Cameras;
 
 import java.io.File;
 import java.time.Instant;
@@ -81,7 +82,9 @@ public class RobotContainer
 
   private final Trigger coralDetector = new Trigger(()-> feeder.hasCoralDisappeared());
 
-  
+  private Cameras cameraEnum = Cameras.CENTER_CAM;
+
+
   
 
 
@@ -306,6 +309,9 @@ public class RobotContainer
       //Feeder Out
       //brodieBox2025.button(3)
 
+      //Rotate towards apriltag toggle
+      logitechController.a()
+        .whileTrue(drivebase.aimAtTarget(cameraEnum));
 
 
       

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -82,7 +82,7 @@ public class RobotContainer
 
   private final Trigger coralDetector = new Trigger(()-> feeder.hasCoralDisappeared());
 
-  private Cameras cameraEnum = Cameras.CENTER_CAM;
+  private final Cameras cameraEnum = Cameras.CENTER_CAM;
 
 
   /**
@@ -197,6 +197,7 @@ public class RobotContainer
     } else
     {
       drivebase.setDefaultCommand(driveFieldOrientedAnglularVelocity);
+      System.out.println("Default Command Ran");
     }
 
     if (Robot.isSimulation())

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -311,9 +311,10 @@ public class RobotContainer
       logitechController.a()
         .whileTrue(drivebase.aimAtTarget(cameraEnum));
 
+      /*
       logitechController.b()
         .whileTrue(drivebase.aimAtTargetBypass(cameraEnum.photonCamera, logitechController));
-
+      */
 
       
       elevatorHighLimit.onTrue(new ParallelCommandGroup(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -311,6 +311,9 @@ public class RobotContainer
       logitechController.a()
         .whileTrue(drivebase.aimAtTarget(cameraEnum));
 
+      logitechController.b()
+        .whileTrue(drivebase.aimAtTargetBypass(cameraEnum.photonCamera, logitechController));
+
 
       
       elevatorHighLimit.onTrue(new ParallelCommandGroup(

--- a/src/main/java/frc/robot/commands/SlowDown.java
+++ b/src/main/java/frc/robot/commands/SlowDown.java
@@ -21,6 +21,7 @@ public class SlowDown extends Command {
   @Override
   public void initialize() {
     drivebase.setSpeedMultipler(Constants.SWERVE_SPEED_SLOW);
+    System.out.println("Slow Down Command Run");
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -31,6 +31,7 @@ import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -264,6 +265,7 @@ public class SwerveSubsystem extends SubsystemBase
       if (resultO.isPresent())
       {
         var result = resultO.get();
+        SmartDashboard.putBoolean("Target Visible: ", result.hasTargets());
         if (result.hasTargets())
         {
           drive(getTargetSpeeds(0,

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -5,7 +5,7 @@
 package frc.robot.subsystems.swervedrive;
 
 import static edu.wpi.first.units.Units.Meter;
-import static edu.wpi.first.units.Units.Rotation;
+//import static edu.wpi.first.units.Units.Rotation;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.commands.PathPlannerAuto;
@@ -74,7 +74,7 @@ public class SwerveSubsystem extends SubsystemBase
   /**
    * Enable vision odometry updates while driving.
    */
-  private final boolean             visionDriveTest     = true;
+  private final boolean             visionDriveTest     = false;
   /**
    * PhotonVision class to keep an accurate odometry.
    */
@@ -274,26 +274,15 @@ public class SwerveSubsystem extends SubsystemBase
       if (resultO.isPresent())
       {
         var result = resultO.get();
-
         if (result.hasTargets())
         {
-          counter++;
-          if (counter >= 5) {
-            System.out.println(getTargetSpeeds(
-              0,
-              0,
-              Rotation2d.fromDegrees(result.getBestTarget()
-              .getYaw())));
-            //System.out.println(Rotation2d.fromDegrees(result.getBestTarget()
-            //.getYaw()));
-            System.out.println(Rotation2d.fromDegrees(result.getBestTarget().getPitch()));
-            counter = 0;
-          }
-
+          
           drive(getTargetSpeeds(0,
                                 0,
-                                Rotation2d.fromDegrees(result.getBestTarget()
-                                .getYaw()))); // Not sure if this will work, more math may be required.
+                                vision.getAdjustedTheta(camera))); // Not sure if this will work, more math may be required.
+          
+          System.out.println("Grabbed Yaw: " + result.getBestTarget().getYaw());
+          System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
         }
       }
     });

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -174,6 +174,8 @@ public class SwerveSubsystem extends SubsystemBase
       vision.updatePoseEstimation(swerveDrive);
     }
     
+    //To Add: Force camera update peridocally with .getEstimatedGlobalPose(Cameras).
+
   }
 
   @Override
@@ -261,6 +263,7 @@ public class SwerveSubsystem extends SubsystemBase
   {
 
     return run(() -> {
+      vision.getEstimatedGlobalPose(camera); //Forces camera update.
       Optional<PhotonPipelineResult> resultO = camera.getBestResult();
       if (resultO.isPresent())
       {

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems.swervedrive;
 
 import static edu.wpi.first.units.Units.Meter;
+import static edu.wpi.first.units.Units.Rotation;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.commands.PathPlannerAuto;
@@ -82,6 +83,8 @@ public class SwerveSubsystem extends SubsystemBase
 
   //true is normal, false is slow
   public boolean speedModifierToggle = true;
+
+  private int counter;
 
   /**
    * Initialize {@link SwerveDrive} with the directory provided.
@@ -261,20 +264,39 @@ public class SwerveSubsystem extends SubsystemBase
    */
   public Command aimAtTarget(Cameras camera)
   {
-
+    //System.out.println("aimAtTarget Running");
     return run(() -> {
-      vision.getEstimatedGlobalPose(camera); //Forces camera update.
-      Optional<PhotonPipelineResult> resultO = camera.getBestResult();
+      //vision.getEstimatedGlobalPose(camera); //Forces camera update.
+      //Optional<PhotonPipelineResult> resultO = camera.getBestResult();
+      Optional<PhotonPipelineResult> resultO = camera.getLatestResult();
+      //System.out.println(resultO);
       if (resultO.isPresent())
       {
         var result = resultO.get();
-        SmartDashboard.putBoolean("Target Visible: ", result.hasTargets());
+
+        //SmartDashboard.putBoolean("Target Visible: ", result.hasTargets());
+        //System.out.println("Result is Present");
         if (result.hasTargets())
         {
+          //System.out.println(Rotation2d.fromDegrees(result.getBestTarget().getYaw()));
+          counter++;
+          if (counter >= 5) {
+            System.out.println(getTargetSpeeds(
+              0,
+              0,
+              Rotation2d.fromDegrees(result.getBestTarget()
+              .getYaw())));
+            //System.out.println(Rotation2d.fromDegrees(result.getBestTarget()
+            //.getYaw()));
+            System.out.println(Rotation2d.fromDegrees(result.getBestTarget().getPitch()));
+            //System.out.println(Rotation2d.fromDegrees(result.getBestTarget()()));
+              counter = 0;
+          }
+
           drive(getTargetSpeeds(0,
                                 0,
                                 Rotation2d.fromDegrees(result.getBestTarget()
-                                                             .getYaw()))); // Not sure if this will work, more math may be required.
+                                .getYaw()))); // Not sure if this will work, more math may be required.
         }
       }
     });

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -37,6 +37,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
 import frc.robot.Constants;
 import frc.robot.Robot;
@@ -49,6 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.json.simple.parser.ParseException;
+import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonUtils;
 import org.photonvision.targeting.PhotonPipelineResult;
 import swervelib.SwerveController;
@@ -292,6 +294,44 @@ public class SwerveSubsystem extends SubsystemBase
           //System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
         }
       }
+    });
+  }
+
+  public Command aimAtTargetBypass (PhotonCamera camera, CommandXboxController controller) {
+    return this.run(()-> {
+      //Joystick input
+      double forward = -controller.getLeftY() * Constants.MAX_SPEED;
+      double strafe = -controller.getLeftX() * Constants.MAX_SPEED;
+      double turn = -controller.getRightX() * Constants.MAX_ANGULAR_SPEED;
+
+      //Vision
+      boolean targetVisible = false;
+      double targetYaw = 0.0;
+
+      var results = camera.getAllUnreadResults();
+      if (!results.isEmpty()) {
+        var result = results.get(results.size() - 1);
+        if (result.hasTargets()) {
+          for (var target : result.getTargets()) {
+            targetYaw = target.getYaw();
+            targetVisible = true;
+            break;
+          }
+        }
+      }
+
+      //Auto-Align if targetVisible
+      if (targetVisible) {
+        turn = targetYaw * Constants.VISION_TURN_kP * Constants.MAX_SPEED;
+      }
+
+      Translation2d translation = new Translation2d(forward, strafe);
+      boolean fieldRelative = true;
+
+      drive(translation, turn, fieldRelative);
+
+      SmartDashboard.putBoolean("Vision Target Visible", targetVisible);
+      SmartDashboard.putNumber("Vision Target Yaw", targetYaw);
     });
   }
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -39,6 +39,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
 import frc.robot.Constants;
+import frc.robot.Robot;
 import frc.robot.subsystems.swervedrive.Vision.Cameras;
 import java.io.File;
 import java.io.IOException;
@@ -79,6 +80,8 @@ public class SwerveSubsystem extends SubsystemBase
    * PhotonVision class to keep an accurate odometry.
    */
   private Vision vision;
+
+  private Robot robot;
 
   public double speedMultiplier = Constants.SWERVE_SPEED_FULL;
 
@@ -276,13 +279,17 @@ public class SwerveSubsystem extends SubsystemBase
         var result = resultO.get();
         if (result.hasTargets())
         {
+          Rotation2d adjustedTheta = vision.getAdjustedTheta(camera);
+          robot.aimAtTargetDegrees.append(adjustedTheta.getDegrees());
+          robot.aimAtTargetRadians.append(adjustedTheta.getRadians());
+          robot.aimAtTargetDegreesNonAdj.append(result.getBestTarget().getYaw());
           
           drive(getTargetSpeeds(0,
                                 0,
                                 vision.getAdjustedTheta(camera))); // Not sure if this will work, more math may be required.
           
-          System.out.println("Grabbed Yaw: " + result.getBestTarget().getYaw());
-          System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
+          //System.out.println("Grabbed Yaw: " + result.getBestTarget().getYaw());
+          //System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
         }
       }
     });

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -168,35 +168,6 @@ public class SwerveSubsystem extends SubsystemBase
     speedModifierToggle = tempFlag;
   }
 
-  public Translation2d getTargetPos(Cameras camera) {
-    Optional<PhotonPipelineResult> result0 = camera.getLatestResult();
-    if (result0.isPresent()) {
-      var result = result0.get();
-
-      if (result.hasTargets()) {
-        double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
-        double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
-        double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
-        (
-          Cameras.CENTER_CAM.robotToCamTransform.getZ(),
-          targetHeight, 
-          0.0,
-          estimatedTargetPitch
-        );
-        
-        Rotation2d estimatedYaw = Rotation2d.fromDegrees(result.getBestTarget().getYaw());
-
-        return PhotonUtils.estimateCameraToTargetTranslation(estimatedTargetDistance, estimatedYaw);
-      } else {
-        DriverStation.reportWarning("Get Target Position called with no targets in sight.", false);
-        return new Translation2d();
-      }
-    }
-
-    DriverStation.reportWarning("Get Target Position Failed; Is Your Camera On?", false);
-    return new Translation2d(); //Camera probably isn't functioning.
-  }
-
   @Override
   public void periodic()
   {

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -281,15 +281,19 @@ public class SwerveSubsystem extends SubsystemBase
         var result = resultO.get();
         if (result.hasTargets())
         {
-          Rotation2d adjustedTheta = vision.getAdjustedTheta(camera);
-          robot.aimAtTargetDegrees.append(adjustedTheta.getDegrees());
-          robot.aimAtTargetRadians.append(adjustedTheta.getRadians());
-          robot.aimAtTargetDegreesNonAdj.append(result.getBestTarget().getYaw());
-          
+          //Rotation2d adjustedTheta = vision.getAdjustedTheta(camera);
+          //robot.aimAtTargetDegrees.append(adjustedTheta.getDegrees());
+          //robot.aimAtTargetRadians.append(adjustedTheta.getRadians());
+          //robot.aimAtTargetDegreesNonAdj.append(result.getBestTarget().getYaw());
+          /*
           drive(getTargetSpeeds(0,
                                 0,
                                 vision.getAdjustedTheta(camera))); // Not sure if this will work, more math may be required.
           
+                                */
+          drive(getTargetSpeeds(0,
+                                0,
+                                Rotation2d.fromDegrees(result.getBestTarget().getYaw()))); // Not sure if this will work, more math may be required.
           //System.out.println("Grabbed Yaw: " + result.getBestTarget().getYaw());
           //System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
         }
@@ -298,8 +302,9 @@ public class SwerveSubsystem extends SubsystemBase
   }
 
   public Command aimAtTargetBypass (PhotonCamera camera, CommandXboxController controller) {
-    return this.run(()-> {
+    return run(()-> {
       //Joystick input
+      System.out.println("Needless Spam");
       double forward = -controller.getLeftY() * Constants.MAX_SPEED;
       double strafe = -controller.getLeftX() * Constants.MAX_SPEED;
       double turn = -controller.getRightX() * Constants.MAX_ANGULAR_SPEED;
@@ -749,7 +754,7 @@ public class SwerveSubsystem extends SubsystemBase
     return swerveDrive.swerveController.getTargetSpeeds(scaledInputs.getX(),
                                                         scaledInputs.getY(),
                                                         angle.getRadians(),
-                                                        getHeading().getRadians(),
+                                                        -getHeading().getRadians(),
                                                         Constants.MAX_SPEED);
   }
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -73,7 +73,7 @@ public class SwerveSubsystem extends SubsystemBase
   /**
    * Enable vision odometry updates while driving.
    */
-  private final boolean             visionDriveTest     = false;
+  private final boolean             visionDriveTest     = true;
   /**
    * PhotonVision class to keep an accurate odometry.
    */
@@ -265,20 +265,17 @@ public class SwerveSubsystem extends SubsystemBase
   public Command aimAtTarget(Cameras camera)
   {
     //System.out.println("aimAtTarget Running");
+    setupPhotonVision();
     return run(() -> {
       //vision.getEstimatedGlobalPose(camera); //Forces camera update.
       //Optional<PhotonPipelineResult> resultO = camera.getBestResult();
       Optional<PhotonPipelineResult> resultO = camera.getLatestResult();
-      //System.out.println(resultO);
       if (resultO.isPresent())
       {
         var result = resultO.get();
 
-        //SmartDashboard.putBoolean("Target Visible: ", result.hasTargets());
-        //System.out.println("Result is Present");
         if (result.hasTargets())
         {
-          //System.out.println(Rotation2d.fromDegrees(result.getBestTarget().getYaw()));
           counter++;
           if (counter >= 5) {
             System.out.println(getTargetSpeeds(
@@ -289,8 +286,7 @@ public class SwerveSubsystem extends SubsystemBase
             //System.out.println(Rotation2d.fromDegrees(result.getBestTarget()
             //.getYaw()));
             System.out.println(Rotation2d.fromDegrees(result.getBestTarget().getPitch()));
-            //System.out.println(Rotation2d.fromDegrees(result.getBestTarget()()));
-              counter = 0;
+            counter = 0;
           }
 
           drive(getTargetSpeeds(0,

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import org.json.simple.parser.ParseException;
+import org.photonvision.PhotonUtils;
 import org.photonvision.targeting.PhotonPipelineResult;
 import swervelib.SwerveController;
 import swervelib.SwerveDrive;
@@ -165,6 +166,35 @@ public class SwerveSubsystem extends SubsystemBase
       setSpeedMultipler(Constants.SWERVE_SPEED_FULL);
     }
     speedModifierToggle = tempFlag;
+  }
+
+  public Translation2d getTargetPos(Cameras camera) {
+    Optional<PhotonPipelineResult> result0 = camera.getLatestResult();
+    if (result0.isPresent()) {
+      var result = result0.get();
+
+      if (result.hasTargets()) {
+        double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
+        double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
+        double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
+        (
+          Cameras.CENTER_CAM.robotToCamTransform.getZ(),
+          targetHeight, 
+          0.0,
+          estimatedTargetPitch
+        );
+        
+        Rotation2d estimatedYaw = Rotation2d.fromDegrees(result.getBestTarget().getYaw());
+
+        return PhotonUtils.estimateCameraToTargetTranslation(estimatedTargetDistance, estimatedYaw);
+      } else {
+        DriverStation.reportWarning("Get Target Position called with no targets in sight.", false);
+        return new Translation2d();
+      }
+    }
+
+    DriverStation.reportWarning("Get Target Position Failed; Is Your Camera On?", false);
+    return new Translation2d(); //Camera probably isn't functioning.
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -270,73 +270,18 @@ public class SwerveSubsystem extends SubsystemBase
    */
   public Command aimAtTarget(Cameras camera)
   {
-    //System.out.println("aimAtTarget Running");
-    setupPhotonVision();
     return run(() -> {
-      //vision.getEstimatedGlobalPose(camera); //Forces camera update.
-      //Optional<PhotonPipelineResult> resultO = camera.getBestResult();
       Optional<PhotonPipelineResult> resultO = camera.getLatestResult();
       if (resultO.isPresent())
       {
         var result = resultO.get();
         if (result.hasTargets())
         {
-          //Rotation2d adjustedTheta = vision.getAdjustedTheta(camera);
-          //robot.aimAtTargetDegrees.append(adjustedTheta.getDegrees());
-          //robot.aimAtTargetRadians.append(adjustedTheta.getRadians());
-          //robot.aimAtTargetDegreesNonAdj.append(result.getBestTarget().getYaw());
-          /*
-          drive(getTargetSpeeds(0,
-                                0,
-                                vision.getAdjustedTheta(camera))); // Not sure if this will work, more math may be required.
-          
-                                */
           drive(getTargetSpeeds(0,
                                 0,
                                 Rotation2d.fromDegrees(result.getBestTarget().getYaw()))); // Not sure if this will work, more math may be required.
-          //System.out.println("Grabbed Yaw: " + result.getBestTarget().getYaw());
-          //System.out.println(" Adjusted Yaw: " + vision.getAdjustedTheta(camera));
         }
       }
-    });
-  }
-
-  public Command aimAtTargetBypass (PhotonCamera camera, CommandXboxController controller) {
-    return run(()-> {
-      //Joystick input
-      System.out.println("Needless Spam");
-      double forward = -controller.getLeftY() * Constants.MAX_SPEED;
-      double strafe = -controller.getLeftX() * Constants.MAX_SPEED;
-      double turn = -controller.getRightX() * Constants.MAX_ANGULAR_SPEED;
-
-      //Vision
-      boolean targetVisible = false;
-      double targetYaw = 0.0;
-
-      var results = camera.getAllUnreadResults();
-      if (!results.isEmpty()) {
-        var result = results.get(results.size() - 1);
-        if (result.hasTargets()) {
-          for (var target : result.getTargets()) {
-            targetYaw = target.getYaw();
-            targetVisible = true;
-            break;
-          }
-        }
-      }
-
-      //Auto-Align if targetVisible
-      if (targetVisible) {
-        turn = targetYaw * Constants.VISION_TURN_kP * Constants.MAX_SPEED;
-      }
-
-      Translation2d translation = new Translation2d(forward, strafe);
-      boolean fieldRelative = true;
-
-      drive(translation, turn, fieldRelative);
-
-      SmartDashboard.putBoolean("Vision Target Visible", targetVisible);
-      SmartDashboard.putNumber("Vision Target Yaw", targetYaw);
     });
   }
 
@@ -754,7 +699,7 @@ public class SwerveSubsystem extends SubsystemBase
     return swerveDrive.swerveController.getTargetSpeeds(scaledInputs.getX(),
                                                         scaledInputs.getY(),
                                                         angle.getRadians(),
-                                                        -getHeading().getRadians(),
+                                                        getHeading().getRadians(),
                                                         Constants.MAX_SPEED);
   }
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -471,7 +471,7 @@ public class Vision
     /**
      * Camera instance for comms.
      */
-    public final  PhotonCamera                 camera;
+    public final  PhotonCamera                 photonCamera;
     /**
      * Pose estimator for camera.
      */
@@ -525,7 +525,7 @@ public class Vision
     {
       latencyAlert = new Alert("'" + name + "' Camera is experiencing high latency.", AlertType.kWarning);
 
-      camera = new PhotonCamera(name);
+      photonCamera = new PhotonCamera(name);
 
       // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
       robotToCamTransform = new Transform3d(robotToCamTranslation, robotToCamRotation);
@@ -551,7 +551,7 @@ public class Vision
         cameraProp.setAvgLatencyMs(35);
         cameraProp.setLatencyStdDevMs(5);
 
-        cameraSim = new PhotonCameraSim(camera, cameraProp);
+        cameraSim = new PhotonCameraSim(photonCamera, cameraProp);
         cameraSim.enableDrawWireframe(true);
       }
     }
@@ -636,7 +636,7 @@ public class Vision
       if ((resultsList.isEmpty() || (currentTimestamp - mostRecentTimestamp >= debounceTime)) &&
           (currentTimestamp - lastReadTimestamp) >= debounceTime)
       {
-        resultsList = Robot.isReal() ? camera.getAllUnreadResults() : cameraSim.getCamera().getAllUnreadResults();
+        resultsList = Robot.isReal() ? photonCamera.getAllUnreadResults() : cameraSim.getCamera().getAllUnreadResults();
         lastReadTimestamp = currentTimestamp;
         resultsList.sort((PhotonPipelineResult a, PhotonPipelineResult b) -> {
           return a.getTimestampSeconds() >= b.getTimestampSeconds() ? 1 : -1;

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -207,7 +207,7 @@ public class Vision
 
     double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
     double cameraPitch = camera.robotToCamTransform.getRotation().getY(); //Should Return 0
-    double targetHeight = Constants.APRILTAG_HEIGHTS[22]; //Dummy Value; Change Later
+    double targetHeight = Constants.APRILTAG_HEIGHTS[23]; //Dummy Value; Change Later
     double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
     (
       Cameras.CENTER_CAM.robotToCamTransform.getZ(),

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.dyn4j.geometry.Rotation;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
@@ -205,7 +207,7 @@ public class Vision
 
     double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
     double cameraPitch = camera.robotToCamTransform.getRotation().getY(); //Should Return 0
-    double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
+    double targetHeight = Constants.APRILTAG_HEIGHTS[22]; //Dummy Value; Change Later
     double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
     (
       Cameras.CENTER_CAM.robotToCamTransform.getZ(),
@@ -245,7 +247,7 @@ public class Vision
   }
 
   //Returns Theta, adjusted from the camera's offset to the relative center of the bot (0,0).
-  public double getAdjustedTheta(Cameras camera, boolean isDegrees) {
+  public Rotation2d getAdjustedTheta(Cameras camera) {
     Translation2d camRelativeTargetPos = getTargetPos(camera);
     Translation2d robotFrameVector = camRelativeTargetPos;
 
@@ -267,18 +269,14 @@ public class Vision
     double thetaAdjusted = Math.atan2(targetY, targetX);
     
     if (getDistanceToTarget(camera) < 0 ) {
-      return 361; //Return Invalid Yaw Because getDistanceToTarget failed.
+      return new Rotation2d(); //Return Invalid Yaw Because getDistanceToTarget failed.
     }
 
     if (camRelativeTargetPos.getNorm() == 0.0) {
-      return 361; //Return Invalid Yaw Because getTargetPos is presumed to have failed.
+      return new Rotation2d(); //Return Invalid Yaw Because getTargetPos is presumed to have failed.
     }
 
-    if (isDegrees) {
-      return Math.toDegrees(thetaAdjusted);
-    }
-    
-    return thetaAdjusted; //Radians
+    return Rotation2d.fromRadians(thetaAdjusted);
   }
 
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.swervedrive;
 
 import static edu.wpi.first.units.Units.Microseconds;
 import static edu.wpi.first.units.Units.Milliseconds;
+import static edu.wpi.first.units.Units.Rotation;
 import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
@@ -189,31 +190,33 @@ public class Vision
   //Default unit for Translation2d is Meters. Inaccurate at lower target pitches.
   public Translation2d getTargetPos(Cameras camera) {
     Optional<PhotonPipelineResult> result0 = camera.getLatestResult();
-    if (result0.isPresent()) {
-      var result = result0.get();
 
-      if (result.hasTargets()) {
-        double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
-        double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
-        double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
-        (
-          Cameras.CENTER_CAM.robotToCamTransform.getZ(),
-          targetHeight, 
-          0.0,
-          estimatedTargetPitch
-        );
-        
-        Rotation2d estimatedYaw = Rotation2d.fromDegrees(result.getBestTarget().getYaw());
-
-        return PhotonUtils.estimateCameraToTargetTranslation(estimatedTargetDistance, estimatedYaw);
-      } else {
-        DriverStation.reportWarning("Get Target Position called with no targets in sight.", false);
-        return new Translation2d();
-      }
+    if (result0.isEmpty()) {
+      DriverStation.reportWarning("Get Target Position Failed; Is Your Camera On?", false);
+      return new Translation2d();
     }
 
-    DriverStation.reportWarning("Get Target Position Failed; Is Your Camera On?", false);
-    return new Translation2d(); //Camera probably isn't functioning.
+    var result = result0.get();
+
+    if (!result.hasTargets()) {
+      DriverStation.reportWarning("Get Target Position called with no targets in sight.", false);
+      return new Translation2d();
+    }
+
+    double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
+    double cameraPitch = camera.robotToCamTransform.getRotation().getY(); //Should Return 0
+    double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
+    double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
+    (
+      Cameras.CENTER_CAM.robotToCamTransform.getZ(),
+      targetHeight, 
+      cameraPitch,
+      estimatedTargetPitch
+    );
+    
+    Rotation2d estimatedYaw = Rotation2d.fromDegrees(-result.getBestTarget().getYaw());
+
+    return PhotonUtils.estimateCameraToTargetTranslation(estimatedTargetDistance, estimatedYaw);
   }
 
   //Inaccurate at lower target pitches.
@@ -243,33 +246,39 @@ public class Vision
 
   //Returns Theta, adjusted from the camera's offset to the relative center of the bot (0,0).
   public double getAdjustedTheta(Cameras camera, boolean isDegrees) {
-    Translation2d originRelativeTargetPos = getTargetPos(camera);
-    double camRelativeTargetX = originRelativeTargetPos.getX();
-    double camRelativeTargetY = originRelativeTargetPos.getY();
+    Translation2d camRelativeTargetPos = getTargetPos(camera);
+    Translation2d robotFrameVector = camRelativeTargetPos;
 
-    double targetX = Cameras.CENTER_CAM.robotToCamTransform.getX() + camRelativeTargetX;
-    double targetY = camRelativeTargetY;
+    Rotation2d camRotation = new Rotation2d(camera.robotToCamTransform.getRotation().getZ()); //Yaw Only
 
-    //If the method above is deemed inaccurate.
-    //double targetX = Cameras.CENTER_CAM.robotToCamTransform.getX() + getDistanceToTarget(camera) + Math.cos(thetaMeasured);
-    //double targetY = getDistanceToTarget(camera) + Math.sin(thetaMeasured);
+    double epsilon = 1e-9; //Small tolerance for floating point comparison.
+
+    //Rotate frame of reference if camera is at an angle.
+    if (Math.abs(camRotation.getRadians()) > epsilon) {
+      robotFrameVector = camRelativeTargetPos.rotateBy(camRotation);
+    }
+
+    double camRelativeTargetX = robotFrameVector.getX();
+    double camRelativeTargetY = robotFrameVector.getY();
+
+    double targetX = camRelativeTargetX + Cameras.CENTER_CAM.robotToCamTransform.getX();
+    double targetY = camRelativeTargetY + Cameras.CENTER_CAM.robotToCamTransform.getY();
 
     double thetaAdjusted = Math.atan2(targetY, targetX);
-    double thetaAdjustedDeg = Math.toDegrees(thetaAdjusted);
     
     if (getDistanceToTarget(camera) < 0 ) {
       return 361; //Return Invalid Yaw Because getDistanceToTarget failed.
     }
 
-    if (getTargetPos(camera).equals(Translation2d.kZero)) {
+    if (camRelativeTargetPos.getNorm() == 0.0) {
       return 361; //Return Invalid Yaw Because getTargetPos is presumed to have failed.
     }
 
     if (isDegrees) {
-      return thetaAdjustedDeg;
-    } else {
-      return thetaAdjusted;
+      return Math.toDegrees(thetaAdjusted);
     }
+    
+    return thetaAdjusted; //Radians
   }
 
 

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -14,6 +14,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
@@ -21,6 +22,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.NetworkTablesJNI;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import frc.robot.Constants;
 import frc.robot.Robot;
@@ -182,6 +184,94 @@ public class Vision
     }
     return poseEst;
   }
+
+
+  //Default unit for Translation2d is Meters. Inaccurate at lower target pitches.
+  public Translation2d getTargetPos(Cameras camera) {
+    Optional<PhotonPipelineResult> result0 = camera.getLatestResult();
+    if (result0.isPresent()) {
+      var result = result0.get();
+
+      if (result.hasTargets()) {
+        double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
+        double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
+        double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
+        (
+          Cameras.CENTER_CAM.robotToCamTransform.getZ(),
+          targetHeight, 
+          0.0,
+          estimatedTargetPitch
+        );
+        
+        Rotation2d estimatedYaw = Rotation2d.fromDegrees(result.getBestTarget().getYaw());
+
+        return PhotonUtils.estimateCameraToTargetTranslation(estimatedTargetDistance, estimatedYaw);
+      } else {
+        DriverStation.reportWarning("Get Target Position called with no targets in sight.", false);
+        return new Translation2d();
+      }
+    }
+
+    DriverStation.reportWarning("Get Target Position Failed; Is Your Camera On?", false);
+    return new Translation2d(); //Camera probably isn't functioning.
+  }
+
+  //Inaccurate at lower target pitches.
+  public double getDistanceToTarget(Cameras camera) {
+    Optional<PhotonPipelineResult> result0 = camera.getLatestResult();
+    if (result0.isPresent()) {
+      var result = result0.get();
+
+      if (result.hasTargets()) {
+        double estimatedTargetPitch = Math.toRadians(result.getBestTarget().getPitch());
+        double targetHeight = Constants.APRILTAG_HEIGHTS[6]; //Dummy Value; Change Later
+        double estimatedTargetDistance = PhotonUtils.calculateDistanceToTargetMeters
+        (
+          Cameras.CENTER_CAM.robotToCamTransform.getZ(),
+          targetHeight, 
+          0.0,
+          estimatedTargetPitch
+        );
+
+        return estimatedTargetDistance;
+      }
+    }
+
+    return -1.0;
+
+  }
+
+  //Returns Theta, adjusted from the camera's offset to the relative center of the bot (0,0).
+  public double getAdjustedTheta(Cameras camera, boolean isDegrees) {
+    Translation2d originRelativeTargetPos = getTargetPos(camera);
+    double camRelativeTargetX = originRelativeTargetPos.getX();
+    double camRelativeTargetY = originRelativeTargetPos.getY();
+
+    double targetX = Cameras.CENTER_CAM.robotToCamTransform.getX() + camRelativeTargetX;
+    double targetY = camRelativeTargetY;
+
+    //If the method above is deemed inaccurate.
+    //double targetX = Cameras.CENTER_CAM.robotToCamTransform.getX() + getDistanceToTarget(camera) + Math.cos(thetaMeasured);
+    //double targetY = getDistanceToTarget(camera) + Math.sin(thetaMeasured);
+
+    double thetaAdjusted = Math.atan2(targetY, targetX);
+    double thetaAdjustedDeg = Math.toDegrees(thetaAdjusted);
+    
+    if (getDistanceToTarget(camera) < 0 ) {
+      return 361; //Return Invalid Yaw Because getDistanceToTarget failed.
+    }
+
+    if (getTargetPos(camera).equals(Translation2d.kZero)) {
+      return 361; //Return Invalid Yaw Because getTargetPos is presumed to have failed.
+    }
+
+    if (isDegrees) {
+      return thetaAdjustedDeg;
+    } else {
+      return thetaAdjusted;
+    }
+  }
+
 
 
   /**

--- a/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/Vision.java
@@ -22,6 +22,7 @@ import edu.wpi.first.networktables.NetworkTablesJNI;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import frc.robot.Constants;
 import frc.robot.Robot;
 import java.awt.Desktop;
 import java.util.ArrayList;
@@ -52,8 +53,8 @@ public class Vision
   /**
    * April Tag Field Layout of the year.
    */
-  public static final AprilTagFieldLayout fieldLayout                     = AprilTagFieldLayout.loadField(
-      AprilTagFields.k2025Reefscape);
+  //public static final AprilTagFieldLayout fieldLayout                     = AprilTagFieldLayout.loadField(
+      //AprilTagFields.k2025Reefscape); - Replaced with Constant.
   /**
    * Ambiguity defined as a value between (0,1). Used in {@link Vision#filterPose}.
    */
@@ -90,7 +91,7 @@ public class Vision
     if (Robot.isSimulation())
     {
       visionSim = new VisionSystemSim("Vision");
-      visionSim.addAprilTags(fieldLayout);
+      visionSim.addAprilTags(Constants.FIELD_LAYOUT);
 
       for (Cameras c : Cameras.values())
       {
@@ -111,13 +112,13 @@ public class Vision
    */
   public static Pose2d getAprilTagPose(int aprilTag, Transform2d robotOffset)
   {
-    Optional<Pose3d> aprilTagPose3d = fieldLayout.getTagPose(aprilTag);
+    Optional<Pose3d> aprilTagPose3d = Constants.FIELD_LAYOUT.getTagPose(aprilTag);
     if (aprilTagPose3d.isPresent())
     {
       return aprilTagPose3d.get().toPose2d().transformBy(robotOffset);
     } else
     {
-      throw new RuntimeException("Cannot get AprilTag " + aprilTag + " from field " + fieldLayout.toString());
+      throw new RuntimeException("Cannot get AprilTag " + aprilTag + " from field " + Constants.FIELD_LAYOUT.toString());
     }
 
   }
@@ -238,7 +239,7 @@ public class Vision
    */
   public double getDistanceFromAprilTag(int id)
   {
-    Optional<Pose3d> tag = fieldLayout.getTagPose(id);
+    Optional<Pose3d> tag = Constants.FIELD_LAYOUT.getTagPose(id);
     return tag.map(pose3d -> PhotonUtils.getDistanceToPose(currentPose.get(), pose3d.toPose2d())).orElse(-1.0);
   }
 
@@ -320,9 +321,9 @@ public class Vision
     List<Pose2d> poses = new ArrayList<>();
     for (PhotonTrackedTarget target : targets)
     {
-      if (fieldLayout.getTagPose(target.getFiducialId()).isPresent())
+      if (Constants.FIELD_LAYOUT.getTagPose(target.getFiducialId()).isPresent())
       {
-        Pose2d targetPose = fieldLayout.getTagPose(target.getFiducialId()).get().toPose2d();
+        Pose2d targetPose = Constants.FIELD_LAYOUT.getTagPose(target.getFiducialId()).get().toPose2d();
         poses.add(targetPose);
       }
     }
@@ -389,7 +390,7 @@ public class Vision
     /**
      * Transform of the camera rotation and translation relative to the center of the robot
      */
-    private final Transform3d                  robotToCamTransform;
+    protected final Transform3d                  robotToCamTransform;
     /**
      * Current standard deviations used.
      */
@@ -432,7 +433,7 @@ public class Vision
       // https://docs.wpilib.org/en/stable/docs/software/basic-programming/coordinate-system.html
       robotToCamTransform = new Transform3d(robotToCamTranslation, robotToCamRotation);
 
-      poseEstimator = new PhotonPoseEstimator(Vision.fieldLayout,
+      poseEstimator = new PhotonPoseEstimator(Constants.FIELD_LAYOUT,
                                               PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
                                               robotToCamTransform);
       poseEstimator.setMultiTagFallbackStrategy(PoseStrategy.LOWEST_AMBIGUITY);


### PR DESCRIPTION
Removes PhotonVision example code in favor of the aimAtTarget Command in the SwerveSubsystem. Currently set to activate while the "a" button of the logitechController is held.